### PR TITLE
Add request/response logging hooks for debugging

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -67,6 +67,9 @@ export type {
   // Config
   StravaRateLimitInfo,
   StravaClientConfig,
+  // Logging
+  StravaRequestInfo,
+  StravaResponseInfo,
 } from "./types";
 
 // Error classes

--- a/types.ts
+++ b/types.ts
@@ -662,6 +662,30 @@ export interface StravaRateLimitInfo {
 }
 
 // ============================================================================
+// Logging Types
+// ============================================================================
+
+export interface StravaRequestInfo {
+  /** HTTP method */
+  method: string;
+  /** Full URL */
+  url: string;
+  /** Request headers (excluding Authorization value for security) */
+  headers: Record<string, string>;
+}
+
+export interface StravaResponseInfo {
+  /** HTTP method */
+  method: string;
+  /** Full URL */
+  url: string;
+  /** HTTP status code */
+  status: number;
+  /** Response time in milliseconds */
+  duration: number;
+}
+
+// ============================================================================
 // Client Configuration
 // ============================================================================
 
@@ -680,4 +704,8 @@ export interface StravaClientConfig {
   timeout?: number;
   /** Optional callback when tokens are refreshed */
   onTokenRefresh?: (tokens: StravaTokens) => void | Promise<void>;
+  /** Optional callback before each request (for logging/debugging) */
+  onRequest?: (info: StravaRequestInfo) => void;
+  /** Optional callback after each response (for logging/debugging) */
+  onResponse?: (info: StravaResponseInfo) => void;
 }


### PR DESCRIPTION
## Summary
- Add optional `onRequest` and `onResponse` callback hooks to `StravaClientConfig` for debugging/logging API requests
- `onRequest` hook called before each request with method, url, and headers (Authorization redacted)
- `onResponse` hook called after each response with method, url, status, and duration in ms
- Refactored `request()` method to use `fetchWithTimeout()` for consistency

## Test plan
- [x] Added tests for onRequest hook being called with correct parameters
- [x] Added tests for onResponse hook being called with correct parameters
- [x] Added tests to verify duration is included and is a valid number
- [x] All 53 tests passing
- [x] TypeScript build succeeds

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)