### PR TITLE
Add webhook subscription management and event parsing

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -70,6 +70,13 @@ export type {
   // Logging
   StravaRequestInfo,
   StravaResponseInfo,
+  // Webhooks
+  StravaWebhookSubscription,
+  StravaWebhookObjectType,
+  StravaWebhookAspectType,
+  StravaWebhookEvent,
+  StravaWebhookVerificationRequest,
+  CreateWebhookSubscriptionOptions,
 } from "./types";
 
 // Error classes

--- a/types.ts
+++ b/types.ts
@@ -686,6 +686,66 @@ export interface StravaResponseInfo {
 }
 
 // ============================================================================
+// Webhook Types
+// ============================================================================
+
+/** Webhook subscription details */
+export interface StravaWebhookSubscription {
+  /** Subscription ID */
+  id: number;
+  /** Application ID */
+  application_id: number;
+  /** Callback URL where webhook events are sent */
+  callback_url: string;
+  /** Timestamp when subscription was created */
+  created_at: string;
+  /** Timestamp when subscription was last updated */
+  updated_at: string;
+}
+
+/** Object type in webhook event */
+export type StravaWebhookObjectType = "activity" | "athlete";
+
+/** Aspect type (action) in webhook event */
+export type StravaWebhookAspectType = "create" | "update" | "delete";
+
+/** Webhook event payload from Strava */
+export interface StravaWebhookEvent {
+  /** Type of object affected - "activity" or "athlete" */
+  object_type: StravaWebhookObjectType;
+  /** ID of the affected activity or athlete */
+  object_id: number;
+  /** Type of action - "create", "update", or "delete" */
+  aspect_type: StravaWebhookAspectType;
+  /** Hash of updated fields (only present for updates) */
+  updates: Record<string, string>;
+  /** Athlete's ID who owns the object */
+  owner_id: number;
+  /** Push subscription ID */
+  subscription_id: number;
+  /** Unix timestamp of the event */
+  event_time: number;
+}
+
+/** Webhook verification challenge request from Strava */
+export interface StravaWebhookVerificationRequest {
+  /** Challenge string to echo back */
+  "hub.challenge": string;
+  /** Mode - always "subscribe" */
+  "hub.mode": string;
+  /** Verification token to validate */
+  "hub.verify_token": string;
+}
+
+/** Options for creating a webhook subscription */
+export interface CreateWebhookSubscriptionOptions {
+  /** URL where Strava will send webhook events */
+  callbackUrl: string;
+  /** Token used to verify the callback URL */
+  verifyToken: string;
+}
+
+// ============================================================================
 // Client Configuration
 // ============================================================================
 


### PR DESCRIPTION
## Summary
- Add webhook subscription management: `createWebhookSubscription()`, `getWebhookSubscription()`, `deleteWebhookSubscription()`
- Add `validateWebhookVerification()` helper for validating callback verification requests from Strava
- Add `parseWebhookEvent()` helper for parsing and validating webhook event payloads
- Add comprehensive webhook type definitions

## Test plan
- [x] Added test for creating webhook subscription
- [x] Added test for getting webhook subscription
- [x] Added test for returning null when no subscription exists
- [x] Added test for deleting webhook subscription
- [x] Added test for validating valid verification request
- [x] Added test for rejecting invalid verify token
- [x] Added test for rejecting invalid hub mode
- [x] Added test for parsing valid webhook event
- [x] Added test for throwing on invalid webhook event
- [x] All 67 tests passing
- [x] TypeScript build succeeds

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)