### PR TITLE
fix: make updates field optional in StravaWebhookEvent

### DIFF
--- a/client.test.ts
+++ b/client.test.ts
@@ -905,12 +905,12 @@ describe("StravaClient", () => {
       expect(challenge).toBeNull();
     });
 
-    it("should parse valid webhook event", () => {
+    it("should parse valid webhook event with updates", () => {
       const payload = {
         object_type: "activity",
         object_id: 12345678,
-        aspect_type: "create",
-        updates: {},
+        aspect_type: "update",
+        updates: { title: "Morning Run" },
         owner_id: 123456,
         subscription_id: 789,
         event_time: 1704067200,
@@ -918,6 +918,21 @@ describe("StravaClient", () => {
 
       const event = client.parseWebhookEvent(payload);
       expect(event).toEqual(payload);
+    });
+
+    it("should parse webhook event without updates field (create/delete events)", () => {
+      const payload = {
+        object_type: "activity",
+        object_id: 12345678,
+        aspect_type: "create",
+        owner_id: 123456,
+        subscription_id: 789,
+        event_time: 1704067200,
+      };
+
+      const event = client.parseWebhookEvent(payload);
+      expect(event).toEqual(payload);
+      expect(event.updates).toBeUndefined();
     });
 
     it("should throw on invalid webhook event", () => {

--- a/types.ts
+++ b/types.ts
@@ -723,8 +723,8 @@ export interface StravaWebhookEvent {
   object_id: number;
   /** Type of action - "create", "update", or "delete" */
   aspect_type: StravaWebhookAspectType;
-  /** Hash of updated fields (only present for updates) */
-  updates: Record<string, string>;
+  /** Hash of updated fields (only present for update events) */
+  updates?: Record<string, string>;
   /** Athlete's ID who owns the object */
   owner_id: number;
   /** Push subscription ID */


### PR DESCRIPTION
## Summary

- Makes the `updates` field optional in `StravaWebhookEvent` interface
- Adds test coverage for webhook events without the updates field (create/delete events)

The `updates` field is only present for 'update' aspect_type events. For 'create' and 'delete' events, Strava does not include this field in the webhook payload.

Fixes #23

## Test plan

- [x] Added test for parsing webhook events without updates field
- [x] All existing tests pass
- [x] TypeScript build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)