### PR TITLE
fix: add enum validation for webhook event object_type and aspect_type

### DIFF
--- a/client.test.ts
+++ b/client.test.ts
@@ -945,6 +945,36 @@ describe("StravaClient", () => {
         "Invalid webhook event payload"
       );
     });
+
+    it("should throw on invalid object_type", () => {
+      const invalidPayload = {
+        object_type: "invalid_type",
+        object_id: 12345678,
+        aspect_type: "create",
+        owner_id: 123456,
+        subscription_id: 789,
+        event_time: 1704067200,
+      };
+
+      expect(() => client.parseWebhookEvent(invalidPayload)).toThrow(
+        "Invalid webhook event payload"
+      );
+    });
+
+    it("should throw on invalid aspect_type", () => {
+      const invalidPayload = {
+        object_type: "activity",
+        object_id: 12345678,
+        aspect_type: "invalid_aspect",
+        owner_id: 123456,
+        subscription_id: 789,
+        event_time: 1704067200,
+      };
+
+      expect(() => client.parseWebhookEvent(invalidPayload)).toThrow(
+        "Invalid webhook event payload"
+      );
+    });
   });
 
   describe("AbortController Support", () => {

--- a/client.ts
+++ b/client.ts
@@ -1229,7 +1229,7 @@ export class StravaClient {
   public parseWebhookEvent(payload: unknown): StravaWebhookEvent {
     const event = payload as StravaWebhookEvent;
 
-    // Basic validation
+    // Basic type validation
     if (
       typeof event.object_type !== "string" ||
       typeof event.object_id !== "number" ||
@@ -1238,6 +1238,18 @@ export class StravaClient {
       typeof event.subscription_id !== "number" ||
       typeof event.event_time !== "number"
     ) {
+      throw new StravaValidationError("Invalid webhook event payload");
+    }
+
+    // Enum validation
+    const validObjectTypes = ["activity", "athlete"];
+    const validAspectTypes = ["create", "update", "delete"];
+
+    if (!validObjectTypes.includes(event.object_type)) {
+      throw new StravaValidationError("Invalid webhook event payload");
+    }
+
+    if (!validAspectTypes.includes(event.aspect_type)) {
       throw new StravaValidationError("Invalid webhook event payload");
     }
 


### PR DESCRIPTION
## Summary

- Adds validation for `object_type` enum values ("activity", "athlete")
- Adds validation for `aspect_type` enum values ("create", "update", "delete")
- Adds test coverage for invalid enum values

This catches malformed webhook events early with clear error messages, preventing invalid data from being processed.

Fixes #25

## Test plan

- [x] Added test for invalid object_type
- [x] Added test for invalid aspect_type  
- [x] All existing tests pass
- [x] TypeScript build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)