### PR TITLE
test: add missing status field in response hook test mock

### DIFF
--- a/client.test.ts
+++ b/client.test.ts
@@ -583,6 +583,7 @@ describe("StravaClient", () => {
               () =>
                 resolve({
                   ok: true,
+                  status: 200,
                   json: () => Promise.resolve({ id: 123 }),
                   headers: new Headers(),
                 }),


### PR DESCRIPTION
## Summary

- Adds missing `status: 200` field to the response hook test mock

This ensures consistency with other test mocks in the suite and prevents potential undefined behavior when the response hook accesses the status field.

Fixes #27

## Test plan

- [x] All tests pass
- [x] TypeScript build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)