### PR TITLE
fix: getTokens() returns a copy to prevent mutation

### DIFF
--- a/client.test.ts
+++ b/client.test.ts
@@ -50,6 +50,24 @@ describe("StravaClient", () => {
       expect(client.getTokens()).toBeNull();
     });
 
+    it("should return a copy of tokens to prevent external mutation", () => {
+      const originalTokens = {
+        accessToken: "access-123",
+        refreshToken: "refresh-456",
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      };
+
+      client.setTokens(originalTokens);
+      const retrievedTokens = client.getTokens();
+
+      // Mutate the retrieved tokens
+      retrievedTokens!.accessToken = "mutated-token";
+
+      // Internal tokens should remain unchanged
+      const internalTokens = client.getTokens();
+      expect(internalTokens!.accessToken).toBe("access-123");
+    });
+
     it("should validate tokens correctly", () => {
       // No tokens
       expect(client.hasValidTokens()).toBe(false);

--- a/client.ts
+++ b/client.ts
@@ -402,10 +402,10 @@ export class StravaClient {
   }
 
   /**
-   * Get current tokens
+   * Get current tokens (returns a copy to prevent external mutation)
    */
   public getTokens(): StravaTokens | null {
-    return this.tokens;
+    return this.tokens ? { ...this.tokens } : null;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fix `getTokens()` to return a shallow copy instead of internal reference
- Prevents callers from accidentally mutating client's internal state

## Test plan
- [x] Added test that verifies mutations to returned tokens don't affect internal state
- [x] All existing tests pass

Fixes #29