### PR TITLE
feat: add AbortSignal support to requestText() and export methods

### DIFF
--- a/client.test.ts
+++ b/client.test.ts
@@ -1075,5 +1075,25 @@ describe("StravaClient", () => {
         })
       );
     });
+
+    it("should support signal for text exports (GPX/TCX)", async () => {
+      const controller = new AbortController();
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve("<gpx></gpx>"),
+        headers: new Headers(),
+      });
+
+      await client.exportRouteGPX(123, { signal: controller.signal });
+
+      // Verify fetch was called with signal
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/routes/123/export_gpx"),
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        })
+      );
+    });
   });
 });

--- a/client.ts
+++ b/client.ts
@@ -45,6 +45,7 @@ import {
   ExploreSegmentsOptions,
   GetSegmentEffortsOptions,
   UploadActivityOptions,
+  RequestOptions,
   StravaWebhookSubscription,
   StravaWebhookEvent,
   StravaWebhookVerificationRequest,
@@ -155,6 +156,7 @@ export class StravaClient {
     options: {
       baseUrl?: string;
       headers?: Record<string, string>;
+      signal?: AbortSignal;
     } = {}
   ): Promise<string> {
     if (this.config.autoRefresh && this.tokens) {
@@ -171,6 +173,7 @@ export class StravaClient {
         ...options.headers,
       },
       parseResponse: (response) => response.text(),
+      signal: options.signal,
     });
   }
 
@@ -912,15 +915,19 @@ export class StravaClient {
   /**
    * Export route as GPX
    */
-  public async exportRouteGPX(routeId: number): Promise<string> {
-    return this.requestText("GET", `/routes/${routeId}/export_gpx`);
+  public async exportRouteGPX(routeId: number, options: RequestOptions = {}): Promise<string> {
+    return this.requestText("GET", `/routes/${routeId}/export_gpx`, {
+      signal: options.signal,
+    });
   }
 
   /**
    * Export route as TCX
    */
-  public async exportRouteTCX(routeId: number): Promise<string> {
-    return this.requestText("GET", `/routes/${routeId}/export_tcx`);
+  public async exportRouteTCX(routeId: number, options: RequestOptions = {}): Promise<string> {
+    return this.requestText("GET", `/routes/${routeId}/export_tcx`, {
+      signal: options.signal,
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary
- Added signal option to `requestText()` private method
- Added `RequestOptions` parameter to `exportRouteGPX()` and `exportRouteTCX()` 
- Ensures consistent cancellation support across all request methods

## Test plan
- [x] Added test verifying signal is passed through for GPX exports
- [x] All existing tests pass

Fixes #31