### PR TITLE
refactor: improve webhook validation with const assertions and pure functions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,12 @@
 // Main client
 export { StravaClient } from "./client";
 
+// Webhook validation functions (pure, can be used standalone)
+export { validateWebhookVerification, parseWebhookEvent } from "./client";
+
+// Constants for webhook validation
+export { STRAVA_WEBHOOK_OBJECT_TYPES, STRAVA_WEBHOOK_ASPECT_TYPES } from "./types";
+
 // Type definitions
 export type {
   // OAuth

--- a/types.ts
+++ b/types.ts
@@ -709,11 +709,17 @@ export interface StravaWebhookSubscription {
   updated_at: string;
 }
 
+/** Valid object types in webhook events (const assertion for runtime validation) */
+export const STRAVA_WEBHOOK_OBJECT_TYPES = ["activity", "athlete"] as const;
+
 /** Object type in webhook event */
-export type StravaWebhookObjectType = "activity" | "athlete";
+export type StravaWebhookObjectType = (typeof STRAVA_WEBHOOK_OBJECT_TYPES)[number];
+
+/** Valid aspect types in webhook events (const assertion for runtime validation) */
+export const STRAVA_WEBHOOK_ASPECT_TYPES = ["create", "update", "delete"] as const;
 
 /** Aspect type (action) in webhook event */
-export type StravaWebhookAspectType = "create" | "update" | "delete";
+export type StravaWebhookAspectType = (typeof STRAVA_WEBHOOK_ASPECT_TYPES)[number];
 
 /** Webhook event payload from Strava */
 export interface StravaWebhookEvent {


### PR DESCRIPTION
## Summary
- Use const assertions for `STRAVA_WEBHOOK_OBJECT_TYPES` and `STRAVA_WEBHOOK_ASPECT_TYPES` to derive types from runtime values (prevents type/validation drift)
- Extract `validateWebhookVerification()` and `parseWebhookEvent()` as pure functions
- Add specific error messages for each validation failure (now tells you exactly which field is wrong)
- Export pure functions and constants for standalone use
- Keep class methods as deprecated wrappers for backwards compatibility

## Breaking Changes
None - class methods still work, just delegate to pure functions now.

## Test plan
- [x] Updated existing tests for new error messages
- [x] Added tests for pure functions
- [x] All 82 tests pass

Fixes #35